### PR TITLE
Add support for generating tiles lazily

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,2 +1,4 @@
+image:
+  - Visual Studio 2022
 install:
   - git submodule update --init --recursive

--- a/opencv-wrapper.h
+++ b/opencv-wrapper.h
@@ -11,6 +11,20 @@ struct opencv_tile
     cv::Rect unique_rect;
 };
 
+inline tiling::rectangle from_opencv_rectangle(const cv::Rect& rect)
+{
+    return tiling::rectangle(
+        tiling::point(
+            rect.x,
+            rect.y
+        ),
+        tiling::size(
+            rect.width,
+            rect.height
+        )
+    );
+}
+
 inline cv::Rect to_opencv_rectangle(const rectangle& rect)
 {
     return cv::Rect(

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -193,6 +193,22 @@ TEST_F(TilingTest, HandlesNegativeOverlapCorrectly) {
     EXPECT_EQ(tiles.size(), 8);
 }
 
+TEST_F(TilingTest, IteratorsGenerallyWorkAsExpected) {
+    const tiling::size input_size(5000, 5000);
+    tiling::parameters parameters;
+    const tiling::tiles tiles(input_size, parameters);
+    EXPECT_EQ(tiles.size(), 3 * 3);
+    auto i = tiles.begin();
+    EXPECT_EQ(i->index.x, 0);
+    EXPECT_EQ(i->index.y, 0);
+    const auto j = i;
+    i++;
+    EXPECT_EQ(i->index.x, 1);
+    EXPECT_EQ(i->index.y, 0);
+    EXPECT_EQ(j->index.x, 0);
+    EXPECT_EQ(j->index.y, 0);
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -249,6 +249,69 @@ TEST_F(TilingTest, IteratorsGenerallyWorkAsExpected) {
     EXPECT_EQ(j->index.y, 0);
 }
 
+TEST_F(TilingTest, SupportsOptionalViewportRectangle) {
+    const tiling::size input_size(5000, 5000);
+    tiling::parameters parameters;
+    parameters.viewport_rect = std::make_optional<tiling::rectangle>(
+        tiling::point(2500, 4000),
+        tiling::size(3000, 500)
+    );
+    const auto tiles = tiling::get_tiles(input_size, parameters);
+    EXPECT_EQ(tiles.size(), 2);
+    for (int i = 0; i < tiles.size(); ++i) {
+        EXPECT_EQ(tiles[i].index.x, i + 1);
+        EXPECT_EQ(tiles[i].index.y, 2);
+    }
+}
+
+TEST_F(TilingTest, ResultContainsTilesOverlappingOptionalViewportAndNoOtherTiles) {
+    const tiling::size input_size(25896, 33943);
+    tiling::parameters parameters;
+    parameters.max_tile_width  = 497;
+    parameters.max_tile_height = 497;
+    parameters.overlap_x = 30;
+    parameters.overlap_y = 30;
+    parameters.limit_to_size = false;
+
+    const auto all_tiles = tiling::get_tiles(input_size, parameters);
+
+    parameters.viewport_rect = std::make_optional<tiling::rectangle>(
+        tiling::point(9678, 16907),
+        tiling::size(751, 891)
+    );
+
+    const auto viewport_tiles = tiling::get_tiles(input_size, parameters);
+
+    const auto is_overlap = [](const tiling::rectangle& lhs, const tiling::rectangle& rhs) {
+        if (lhs.top_left.x + lhs.size.width < rhs.top_left.x) {
+            return false;
+        }
+        if (lhs.top_left.y + lhs.size.height < rhs.top_left.y) {
+            return false;
+        }
+        if (rhs.top_left.x + rhs.size.width < lhs.top_left.x) {
+            return false;
+        }
+        if (rhs.top_left.y + rhs.size.height < lhs.top_left.y) {
+            return false;
+        }
+        return true;
+    };
+
+    for (const auto& tile : all_tiles) {
+        const auto should_be_viewport_tile = is_overlap(tile.full_rect, *parameters.viewport_rect);
+        const auto is_viewport_tile = std::find_if(
+            viewport_tiles.begin(),
+            viewport_tiles.end(),
+            [&tile](const tiling::tile& candidate) {
+                return candidate.index.x == tile.index.x
+                    && candidate.index.y == tile.index.y;
+            }
+        ) != viewport_tiles.end();
+        EXPECT_EQ(should_be_viewport_tile, is_viewport_tile);
+    }
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -29,32 +29,32 @@
     <ProjectGuid>{06823804-4A55-4358-B169-E29E9AB236FB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>mark-unmarked-areas-clean</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
@@ -126,6 +126,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -168,6 +169,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/tiling.cpp
+++ b/tiling.cpp
@@ -46,7 +46,7 @@ int find_viewport_count(int starting_center, int stride, int end)
 tiles::tiles(const tiling::size& size, const tiling::parameters& parameters)
     : width (size.width)
     , height(size.height)
-    , parameters(parameters)
+    , params(parameters)
     , full_image_starting_center_x(find_starting_center(size.width,  parameters.max_tile_width,  parameters.overlap_x))
     , full_image_starting_center_y(find_starting_center(size.height, parameters.max_tile_height, parameters.overlap_y))
     , stride_x(parameters.max_tile_width  - parameters.overlap_x)
@@ -73,18 +73,18 @@ tiles::const_iterator::const_iterator(const tiles* parent, int center_x, int cen
 
 const tile& tiles::const_iterator::operator*() const
 {
-    if (!tile.has_value()) {
+    if (!t.has_value()) {
         update();
     }
-    return tile.value();
+    return t.value();
 }
 
 const tile* tiles::const_iterator::operator->() const
 {
-    if (!tile.has_value()) {
+    if (!t.has_value()) {
         update();
     }
-    return &tile.value();
+    return &t.value();
 }
 
 tiles::const_iterator& tiles::const_iterator::operator++() // prefix increment
@@ -143,12 +143,12 @@ void tiles::const_iterator::increment()
         *this = parent->end();
     }
 
-    tile.reset();
+    t.reset();
 }
 
 void tiles::const_iterator::update() const
 {
-    assert(!tile.has_value());
+    assert(!t.has_value());
 
     const bool is_topmost_row = center_y == parent->full_image_starting_center_y;
     const bool is_bottommost_row = center_y + parent->stride_y >= parent->height;
@@ -156,7 +156,7 @@ void tiles::const_iterator::update() const
     const bool is_leftmost_column = center_x == parent->full_image_starting_center_x;
     const bool is_rightmost_column = center_x + parent->stride_x >= parent->width;
 
-    const auto& parameters = parent->parameters;
+    const auto& parameters = parent->params;
 
     const int desired_left   = center_x - parameters.max_tile_width  / 2;
     const int desired_top    = center_y - parameters.max_tile_height / 2;
@@ -168,7 +168,7 @@ void tiles::const_iterator::update() const
     const int right  = parameters.limit_to_size ? std::min(desired_right , parent->width)  : desired_right;
     const int bottom = parameters.limit_to_size ? std::min(desired_bottom, parent->height) : desired_bottom;
 
-    auto& t = tile.emplace();
+    auto& t = this->t.emplace();
 
     t.index.x = index_x;
     t.index.y = index_y;

--- a/tiling.cpp
+++ b/tiling.cpp
@@ -22,85 +22,190 @@ int find_starting_center(int full_dimension, int tile_dimension, int overlap)
     return starting_center;
 }
 
+tiles::tiles(const tiling::size& size, const tiling::parameters& parameters)
+    : width (size.width)
+    , height(size.height)
+    , parameters(parameters)
+    , starting_center_x(find_starting_center(size.width,  parameters.max_tile_width,  parameters.overlap_x))
+    , starting_center_y(find_starting_center(size.height, parameters.max_tile_height, parameters.overlap_y))
+    , stride_x(parameters.max_tile_width  - parameters.overlap_x)
+    , stride_y(parameters.max_tile_height - parameters.overlap_y)
+    , count_x((size.width  - starting_center_x - 1) / stride_x + 1)
+    , count_y((size.height - starting_center_y - 1) / stride_y + 1)
+{}
+
+tiles::const_iterator::const_iterator(const tiles* parent, int center_x, int center_y, int index_x, int index_y)
+    : parent(parent)
+    , center_x(center_x)
+    , center_y(center_y)
+    , index_x(index_x)
+    , index_y(index_y)
+{}
+
+const tile& tiles::const_iterator::operator*()
+{
+    if (!tile.has_value()) {
+        update();
+    }
+    return tile.value();
+}
+
+const tile* tiles::const_iterator::operator->()
+{
+    if (!tile.has_value()) {
+        update();
+    }
+    return &tile.value();
+}
+
+tiles::const_iterator& tiles::const_iterator::operator++() // prefix increment
+{
+    increment();
+    return *this;
+ }
+
+tiles::const_iterator tiles::const_iterator::operator++(int) // postfix increment
+{
+    const auto output = *this;
+    increment();
+    return output;
+}
+
+bool operator ==(const tiles::const_iterator& lhs, const tiles::const_iterator& rhs)
+{
+    return lhs.center_x == rhs.center_x
+        && lhs.center_y == rhs.center_y
+        && lhs.index_x == rhs.index_x
+        && lhs.index_y == rhs.index_y;
+}
+
+bool operator !=(const tiles::const_iterator& lhs, const tiles::const_iterator& rhs)
+{
+    return !operator ==(lhs, rhs);
+}
+
+void tiles::const_iterator::increment_x()
+{
+    center_x += parent->stride_x;
+    ++index_x;
+
+    assert((center_x >= parent->width) == (index_x >= parent->count_x));
+}
+
+void tiles::const_iterator::increment_y()
+{
+    center_y += parent->stride_y;
+    ++index_y;
+
+    assert((center_y >= parent->height) == (index_y >= parent->count_y));
+}
+
+void tiles::const_iterator::increment()
+{
+    increment_x();
+
+    if (center_x >= parent->width) {
+        increment_y();
+
+        center_x = parent->starting_center_x;
+        index_x = 0;
+    }
+
+    if (center_y >= parent->height) {
+        *this = parent->end();
+    }
+
+    tile.reset();
+}
+
+void tiles::const_iterator::update()
+{
+    assert(!tile.has_value());
+
+    const bool is_topmost_row = center_y == parent->starting_center_y;
+    const bool is_bottommost_row = center_y + parent->stride_y >= parent->height;
+
+    const bool is_leftmost_column = center_x == parent->starting_center_x;
+    const bool is_rightmost_column = center_x + parent->stride_x >= parent->width;
+
+    const auto& parameters = parent->parameters;
+
+    const int desired_left   = center_x - parameters.max_tile_width  / 2;
+    const int desired_top    = center_y - parameters.max_tile_height / 2;
+    const int desired_right  = desired_left + parameters.max_tile_width;
+    const int desired_bottom = desired_top  + parameters.max_tile_height;
+
+    const int left   = parameters.limit_to_size ? std::max(0, desired_left) : desired_left;
+    const int top    = parameters.limit_to_size ? std::max(0, desired_top)  : desired_top;
+    const int right  = parameters.limit_to_size ? std::min(desired_right , parent->width)  : desired_right;
+    const int bottom = parameters.limit_to_size ? std::min(desired_bottom, parent->height) : desired_bottom;
+
+    auto& t = tile.emplace();
+
+    t.index.x = index_x;
+    t.index.y = index_y;
+
+    t.full_rect.top_left.x = left;
+    t.full_rect.top_left.y = top;
+    t.full_rect.size.width = right - left;
+    t.full_rect.size.height = bottom - top;
+
+    t.non_overlapping_rect.top_left.x = is_leftmost_column ? left : left + (parameters.overlap_x + 1) / 2;
+    t.non_overlapping_rect.top_left.y = is_topmost_row ? top : top + (parameters.overlap_y + 1) / 2;
+
+    t.unique_rect.top_left.x = is_leftmost_column ? left : left + parameters.overlap_x;
+    t.unique_rect.top_left.y = is_topmost_row ? top : top + parameters.overlap_y;
+
+    const int non_overlapping_rect_right  = is_rightmost_column ? right  : right  - parameters.overlap_x / 2;
+    const int non_overlapping_rect_bottom = is_bottommost_row   ? bottom : bottom - parameters.overlap_y / 2;
+
+    t.non_overlapping_rect.size.width  = non_overlapping_rect_right  - t.non_overlapping_rect.top_left.x;
+    t.non_overlapping_rect.size.height = non_overlapping_rect_bottom - t.non_overlapping_rect.top_left.y;
+
+    const int unique_rect_right  = is_rightmost_column ? right  : right  - parameters.overlap_x;
+    const int unique_rect_bottom = is_bottommost_row   ? bottom : bottom - parameters.overlap_y;
+
+    t.unique_rect.size.width  = unique_rect_right  - t.unique_rect.top_left.x;
+    t.unique_rect.size.height = unique_rect_bottom - t.unique_rect.top_left.y;
+}
+
+tiles::const_iterator tiles::begin() const
+{
+    return const_iterator(this, starting_center_x, starting_center_y, 0, 0);
+}
+
+tiles::const_iterator tiles::end() const
+{
+    return const_iterator(this, width, height, count_x, count_y);
+}
+
+size_t tiles::size() const
+{
+    return static_cast<size_t>(count_x) * static_cast<size_t>(count_y);
+}
+
+// wrapper for backward compatibility
 std::vector<tile> get_tiles(const size& size, const parameters& parameters, std::function<bool()> isCancelled)
 {
-    if (parameters.max_tile_width <= parameters.overlap_x) {
-        throw std::runtime_error("parameters.max_tile_width <= parameters.overlap_x : " + std::to_string(parameters.max_tile_width) + " <= " + std::to_string(parameters.overlap_x));
-    }
-    if (parameters.max_tile_height <= parameters.overlap_y) {
-        throw std::runtime_error("parameters.max_tile_height <= parameters.overlap_y : " + std::to_string(parameters.max_tile_height) + " <= " + std::to_string(parameters.overlap_y));
-    }
+    const tiling::tiles tiles(size, parameters);
 
-    const point starting_center(
-        find_starting_center(size.width, parameters.max_tile_width, parameters.overlap_x),
-        find_starting_center(size.height, parameters.max_tile_height, parameters.overlap_y)
-    );
+    std::vector<tile> output(tiles.size());
 
-    std::vector<tile> tiles;
+    size_t i = 0;
 
-    const int stride_x = parameters.max_tile_width  - parameters.overlap_x;
-    const int stride_y = parameters.max_tile_height - parameters.overlap_y;
+    for (auto j = tiles.begin(), end = tiles.end(); j != end; ++i, ++j) {
+        output[i] = *j;
 
-    const int count_x = (size.width  - starting_center.x - 1) / stride_x + 1;
-    const int count_y = (size.height - starting_center.y - 1) / stride_y + 1;
-
-    tiles.reserve(static_cast<int64_t>(count_x) * static_cast<int64_t>(count_y));
-
-    for (int center_y = starting_center.y, index_y = 0; center_y < size.height && !isCancelled(); center_y += stride_y, ++index_y) {
-
-        const bool is_topmost_row = center_y == starting_center.y;
-        const bool is_bottommost_row = center_y + stride_y >= size.height;
-
-        for (int center_x = starting_center.x, index_x = 0; center_x < size.width; center_x += stride_x, ++index_x) {
-
-            const bool is_leftmost_column = center_x == starting_center.x;
-            const bool is_rightmost_column = center_x + stride_x >= size.width;
-
-            const int desired_left = center_x - parameters.max_tile_width / 2;
-            const int desired_top = center_y - parameters.max_tile_height / 2;
-            const int desired_right = desired_left + parameters.max_tile_width;
-            const int desired_bottom = desired_top + parameters.max_tile_height;
-            
-            const int left   = parameters.limit_to_size ? std::max(0, desired_left)             : desired_left;
-            const int top    = parameters.limit_to_size ? std::max(0, desired_top)              : desired_top;
-            const int right  = parameters.limit_to_size ? std::min(desired_right, size.width)   : desired_right;
-            const int bottom = parameters.limit_to_size ? std::min(desired_bottom, size.height) : desired_bottom;
-
-            const tiling::point top_left(left, top);
-            const tiling::size tile_size(right - left, bottom - top);
-            
-            tile t;
-            t.index = point(index_x, index_y);
-            t.full_rect = rectangle(top_left, tile_size);
-
-            t.non_overlapping_rect.top_left.x = is_leftmost_column ? top_left.x : top_left.x + (parameters.overlap_x + 1) / 2;
-            t.non_overlapping_rect.top_left.y = is_topmost_row ? top_left.y : top_left.y + (parameters.overlap_y + 1) / 2;
-
-            t.unique_rect.top_left.x = is_leftmost_column ? top_left.x : top_left.x + parameters.overlap_x;
-            t.unique_rect.top_left.y = is_topmost_row ? top_left.y : top_left.y + parameters.overlap_y;
-
-            const int full_rect_right = top_left.x + tile_size.width;
-            const int full_rect_bottom = top_left.y + tile_size.height;
-
-            const int non_overlapping_rect_right = is_rightmost_column ? full_rect_right : full_rect_right - parameters.overlap_x / 2;
-            const int non_overlapping_rect_bottom = is_bottommost_row ? full_rect_bottom : full_rect_bottom - parameters.overlap_y / 2;
-
-            t.non_overlapping_rect.size.width = non_overlapping_rect_right - t.non_overlapping_rect.top_left.x;
-            t.non_overlapping_rect.size.height = non_overlapping_rect_bottom - t.non_overlapping_rect.top_left.y;
-
-            const int unique_rect_right = is_rightmost_column ? full_rect_right : full_rect_right - parameters.overlap_x;
-            const int unique_rect_bottom = is_bottommost_row ? full_rect_bottom : full_rect_bottom - parameters.overlap_y;
-
-            t.unique_rect.size.width = unique_rect_right - t.unique_rect.top_left.x;
-            t.unique_rect.size.height = unique_rect_bottom - t.unique_rect.top_left.y;
-
-            tiles.push_back(t);
+        if (i % 1000 == 0) {
+            if (isCancelled()) {
+                break;
+            }
         }
     }
 
-    assert(tiles.size() == static_cast<size_t>(count_x * count_y) || isCancelled());
+    assert(i == output.size() || isCancelled());
 
-    return tiles;
+    return output;
 }
 
 }

--- a/tiling.cpp
+++ b/tiling.cpp
@@ -42,7 +42,7 @@ tiles::const_iterator::const_iterator(const tiles* parent, int center_x, int cen
     , index_y(index_y)
 {}
 
-const tile& tiles::const_iterator::operator*()
+const tile& tiles::const_iterator::operator*() const
 {
     if (!tile.has_value()) {
         update();
@@ -50,7 +50,7 @@ const tile& tiles::const_iterator::operator*()
     return tile.value();
 }
 
-const tile* tiles::const_iterator::operator->()
+const tile* tiles::const_iterator::operator->() const
 {
     if (!tile.has_value()) {
         update();
@@ -84,24 +84,23 @@ bool operator !=(const tiles::const_iterator& lhs, const tiles::const_iterator& 
     return !operator ==(lhs, rhs);
 }
 
-void tiles::const_iterator::increment_x()
-{
-    center_x += parent->stride_x;
-    ++index_x;
-
-    assert((center_x >= parent->width) == (index_x >= parent->count_x));
-}
-
-void tiles::const_iterator::increment_y()
-{
-    center_y += parent->stride_y;
-    ++index_y;
-
-    assert((center_y >= parent->height) == (index_y >= parent->count_y));
-}
-
 void tiles::const_iterator::increment()
 {
+    const auto increment_dim = [](int& center, int& index, int stride, int size, int count) {
+        center += stride;
+        index += 1;
+
+        assert((center >= size) == (index >= count));
+    };
+
+    const auto increment_x = [&] {
+        increment_dim(center_x, index_x, parent->stride_x, parent->width, parent->count_x);
+    };
+
+    const auto increment_y = [&] {
+        increment_dim(center_y, index_y, parent->stride_y, parent->height, parent->count_y);
+    };
+
     increment_x();
 
     if (center_x >= parent->width) {
@@ -118,7 +117,7 @@ void tiles::const_iterator::increment()
     tile.reset();
 }
 
-void tiles::const_iterator::update()
+void tiles::const_iterator::update() const
 {
     assert(!tile.has_value());
 

--- a/tiling.h
+++ b/tiling.h
@@ -53,8 +53,8 @@ public:
     struct const_iterator {
         const_iterator(const tiles* parent, int center_x, int center_y, int index_x, int index_y);
 
-        const tile& operator*();
-        const tile* operator->();
+        const tile& operator*() const;
+        const tile* operator->() const;
         
         const_iterator& operator++();
         const_iterator operator++(int);
@@ -63,13 +63,10 @@ public:
         friend bool operator !=(const const_iterator& lhs, const const_iterator& rhs);
 
     private:
-        void increment_x();
-        void increment_y();
-
         void increment();
-        void update();
+        void update() const;
 
-        std::optional<tile> tile;
+        mutable std::optional<tile> tile;
 
         const tiles* parent;
         int center_x;

--- a/tiling.h
+++ b/tiling.h
@@ -67,7 +67,7 @@ public:
         void increment();
         void update() const;
 
-        mutable std::optional<tile> tile;
+        mutable std::optional<tile> t;
 
         const tiles* parent;
         int center_x;
@@ -84,7 +84,7 @@ public:
 private:
     const int width;
     const int height;
-    const parameters parameters;
+    const parameters params;
     const int full_image_starting_center_x;
     const int full_image_starting_center_y;
     const int stride_x;

--- a/tiling.h
+++ b/tiling.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <functional>
+#include <optional>
 
 namespace tiling {
 
@@ -45,6 +46,56 @@ struct parameters {
     bool limit_to_size = true;
 };
 
+class tiles {
+public:
+    tiles(const size& size, const parameters& parameters);
+
+    struct const_iterator {
+        const_iterator(const tiles* parent, int center_x, int center_y, int index_x, int index_y);
+
+        const tile& operator*();
+        const tile* operator->();
+        
+        const_iterator& operator++();
+        const_iterator operator++(int);
+
+        friend bool operator ==(const const_iterator& lhs, const const_iterator& rhs);
+        friend bool operator !=(const const_iterator& lhs, const const_iterator& rhs);
+
+    private:
+        void increment_x();
+        void increment_y();
+
+        void increment();
+        void update();
+
+        std::optional<tile> tile;
+
+        const tiles* parent;
+        int center_x;
+        int center_y;
+        int index_x;
+        int index_y;
+    };
+
+    const_iterator begin() const;
+    const_iterator end() const;
+
+    size_t size() const;
+
+private:
+    const int width;
+    const int height;
+    const parameters parameters;
+    const int starting_center_x;
+    const int starting_center_y;
+    const int stride_x;
+    const int stride_y;
+    const int count_x;
+    const int count_y;
+};
+
+// wrapper for backward compatibility
 std::vector<tile> get_tiles(const size& size, const parameters& parameters, std::function<bool()> isCancelled = []() { return false; });
 
 }

--- a/tiling.h
+++ b/tiling.h
@@ -44,6 +44,7 @@ struct parameters {
     int overlap_x = 227;
     int overlap_y = 227;
     bool limit_to_size = true;
+    std::optional<rectangle> viewport_rect;
 };
 
 class tiles {
@@ -84,12 +85,20 @@ private:
     const int width;
     const int height;
     const parameters parameters;
-    const int starting_center_x;
-    const int starting_center_y;
+    const int full_image_starting_center_x;
+    const int full_image_starting_center_y;
     const int stride_x;
     const int stride_y;
-    const int count_x;
-    const int count_y;
+    const int full_image_count_x;
+    const int full_image_count_y;
+    const int viewport_start_index_x;
+    const int viewport_start_index_y;
+    const int viewport_starting_center_x;
+    const int viewport_starting_center_y;
+    const int viewport_end_x;
+    const int viewport_end_y;
+    const int viewport_count_x;
+    const int viewport_count_y;
 };
 
 // wrapper for backward compatibility


### PR DESCRIPTION
**Problem**: sometimes the entire vector of tiles may be prohibitively large to keep in memory at one time

**Solution**: add support for generating the actual tiles on demand, without requiring to instantiate all of them in memory at any one time